### PR TITLE
Fix pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,19 +1,18 @@
 systemd:
-  units:
-    service:
-      syncthing-someuser:
-        Unit:
-          Description: Syncthing P2P sync service for someuser
-          After: network.target
+  service:
+    syncthing-someuser:
+      Unit:
+        Description: Syncthing P2P sync service for someuser
+        After: network.target
   
-        Service:
-          ExecStart: /usr/bin/syncthing
-          User: someuser
-          Group: someuser
-          Environment: STNORESTART=yes HOME=/home/someuser
+      Service:
+        ExecStart: /usr/bin/syncthing
+        User: someuser
+        Group: someuser
+        Environment: STNORESTART=yes HOME=/home/someuser
   
-        Install:
-          WantedBy: multi-user.target
+      Install:
+        WantedBy: multi-user.target
 
   networkd:
     profiles:


### PR DESCRIPTION
pillar.example was wrong. After analyzing how exactly unit files will be created I found that 'units:' section was wrong and affected naming of files.