### PR TITLE
replace iteritems with items for python3

### DIFF
--- a/systemd/units/init.sls
+++ b/systemd/units/init.sls
@@ -1,5 +1,5 @@
-{% for unittype, units in pillar['systemd'].iteritems()  %}
-{% for unit, unitconfig in units.iteritems() %}
+{% for unittype, units in pillar['systemd'].items()  %}
+{% for unit, unitconfig in units.items() %}
 
 /etc/systemd/system/{{ unit }}.{{ unittype }}:
   file.managed:

--- a/systemd/units/unit.jinja
+++ b/systemd/units/unit.jinja
@@ -1,6 +1,6 @@
-{% for section, sectioncontent in config.iteritems() -%}
+{% for section, sectioncontent in config.items() -%}
 [{{ section }}]
-{% for key, value in sectioncontent.iteritems() -%}
+{% for key, value in sectioncontent.items() -%}
 {{ key }}={{ value }}
 {% endfor %}
 {% endfor -%}


### PR DESCRIPTION
iteritems is deprecated in python3, we should use items()