### PR TITLE
Improve timesyncd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Bundler
+Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,25 +7,14 @@ driver_config:
   use_sudo: false
   privileged: true
   require_chef_omnibus: false
-  cap_add:
-    - SYS_PTRACE
 
 platforms:
-  - name: centos-7
-    driver_config:
-      provision_command:
-        - yum -y install initscripts 
-      platform: rhel
-      run_command: /usr/lib/systemd/systemd
-      privileged: true
-      pid_one_command: /usr/lib/systemd/systemd
-  - name: ubuntu-16.04
+  - name: debian-stretch
     driver_config:
       provision_command:
         - apt-get update && apt-get install -y locales && locale-gen en_US.UTF-8
-      run_command: /lib/systemd/systemd
+      run_command: /lib/systemd/systemd --system
       pid_one_command: /lib/systemd/systemd
-      privileged: true
 
 provisioner:
   name: salt_solo
@@ -48,17 +37,12 @@ provisioner:
         - systemd
         - systemd.networkd
         - systemd.networkd.profiles
+        - systemd.timesyncd
 
 verifier:
   name: serverspec
-  use_sudo: yes
-  sudo_path: true
 
 suites:
   - name: default
     verifier:
       default_pattern: true
-      bundler_path: '/usr/local/bin'
-      rspec_path: '/usr/local/bin'
-      env_vars:
-        SUDO: true

--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,11 @@ Installs the systemd packages and libraries.
 
 ``systemd.timesyncd``
 ---------------------
-This state installs systemd-timesyncd 
+This state installs systemd-timesyncd and configures both NTP and timezone
 
 ``systemd.networkd``
 --------------------
-This state installs systemd-networkd and recursive add files per os_family/minion_id
+This state installs systemd-networkd and recursively adds files per os_family/minion_id
 
 ``systemd.networkd.profiles``
 --------------------
@@ -48,7 +48,7 @@ This state installs systemd-networkd profile files from pillar see pillar.exampl
 
 ``systemd.resolved``
 --------------------
-This state installs systemd-resolved and add the timesyncd.conf file per os_family/minion_id
+This state installs systemd-resolved and adds the timesyncd.conf file per os_family/minion_id
 
 ``systemd.units``
 -----------------

--- a/pillar.example
+++ b/pillar.example
@@ -46,3 +46,7 @@ systemd:
           - Link:
             - Name: internet0
 
+  timesyncd:
+    lookup:
+      timezone: 'UTC'
+

--- a/systemd/timesyncd/defaults.yml
+++ b/systemd/timesyncd/defaults.yml
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+timesyncd:
+  timezone: 'UTC'

--- a/systemd/timesyncd/files/Debian/timesyncd.conf
+++ b/systemd/timesyncd/files/Debian/timesyncd.conf
@@ -1,0 +1,19 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+#NTP=
+#FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+#RootDistanceMaxSec=5
+#PollIntervalMinSec=32
+#PollIntervalMaxSec=2048

--- a/systemd/timesyncd/files/Ubuntu/timesyncd.conf
+++ b/systemd/timesyncd/files/Ubuntu/timesyncd.conf
@@ -1,0 +1,19 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+#NTP=
+#FallbackNTP=ntp.ubuntu.com
+#RootDistanceMaxSec=5
+#PollIntervalMinSec=32
+#PollIntervalMaxSec=2048

--- a/systemd/timesyncd/init.sls
+++ b/systemd/timesyncd/init.sls
@@ -1,3 +1,4 @@
+{%- from "systemd/timesyncd/map.jinja" import timesyncd with context -%}
 {% from "systemd/timesyncd/macros.jinja" import files_switch with context -%}
 
 timesyncd:
@@ -12,6 +13,10 @@ timesyncd:
   service.running:
     - name: systemd-timesyncd
     - enable: True
+    - require:
+      - cmd: daemon-reload
+  timezone.system:
+    - name: {{ timesyncd.timezone }}
 
 # This is necessary in order to allow timesyncd to run on virtual machines.
 daemon-reload:
@@ -19,7 +24,7 @@ daemon-reload:
     - name: systemctl daemon-reload
     - runas: root
 
-{%- if grains['virtual'] != "physical" %}
+{%- if grains['virtual'] != "physical" or grains['virtual_subtype'] == "Docker" %}
 timesyncd-allowvirtual:
   file.managed:
     - name: /etc/systemd/system/systemd-timesyncd.service.d/allowvirtual.conf

--- a/systemd/timesyncd/map.jinja
+++ b/systemd/timesyncd/map.jinja
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{## Start with  defaults from defaults.sls ##}
+{% import_yaml 'systemd/timesyncd/defaults.yml' as default_settings %}
+
+{## Get lookup variables from pillar ##}
+{% set timesyncd_lookup = salt['pillar.get']('systemd:timesyncd:lookup', {}).copy() %}
+
+{## setup variable using grains['os_family'] based logic ##}
+{% set os_family_map = salt['grains.filter_by']({
+        'Arch': {},
+        'RedHat': {},
+        'Suse': {},
+        'Debian': {},
+  },
+  grain="os_family",
+  merge=timesyncd_lookup)
+%}
+
+{## Merge the flavor_map to the default settings ##}
+{% do default_settings.timesyncd.update(os_family_map) %}
+
+{## Merge in timesyncd pillar ##}
+{% set timesyncd = salt['pillar.get'](
+        'timesyncd',
+        default=default_settings.timesyncd,
+        merge=True
+    )
+%}

--- a/test/integration/default/serverspec/timesyncd_spec.rb
+++ b/test/integration/default/serverspec/timesyncd_spec.rb
@@ -1,0 +1,19 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe command('systemctl is-enabled systemd-timesyncd.service') do
+  its('stdout') { should eq "enabled\n" }
+end
+
+describe command('systemctl is-active systemd-timesyncd.service') do
+  its('stdout') { should eq "active\n" }
+end
+
+describe command('timedatectl | grep "NTP synchronized"') do
+  its('stdout') { should match /yes$/ }
+end
+
+describe command('timedatectl | grep "Time zone"') do
+  its('stdout') { should match /UTC/ }
+end


### PR DESCRIPTION
Hello,

This PR adds timezone support (through the native timezone state which is using timedatectl) as well as  configuration templates for Debian and Ubuntu.

I also modified the Kitchen tests because the Ubuntu 16.04 based one was crashing my TTYs (link with issues referenced on https://github.com/moby/moby/issues/28614 ?) and because systemd-timesyncd on Centos 7 doesn't support NTP.

Feel free to comment and / or ask for changes.

Best regards,