### PR TITLE
Restore Ubuntu tests, now using 17.10

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,14 @@ platforms:
         - locale-gen en_US.UTF-8
       run_command: /lib/systemd/systemd
       pid_one_command: /lib/systemd/systemd
+  - name: ubuntu-17.10
+    driver_config:
+      provision_command:
+        - apt-get update && apt-get install -y locales
+        - echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+        - locale-gen en_US.UTF-8
+      run_command: /lib/systemd/systemd
+      pid_one_command: /lib/systemd/systemd
 
 provisioner:
   name: salt_solo
@@ -62,6 +70,7 @@ suites:
       default_pattern: true
     includes:
       - debian-9
+      - ubuntu-17.10
     provisioner:
       state_top:
         base:


### PR DESCRIPTION
Hello,

Here is a quick MR to restore Kitchen tests for Ubuntu, now using 17.10.

We will probably switch to 18.04 as from April 2018.

Best regards,