### PR TITLE
Units in pillars

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -65,6 +65,7 @@ suites:
             - systemd
             - systemd.networkd
             - systemd.networkd.profiles
+            - systemd.units
   - name: ntp
     verifier:
       default_pattern: true
@@ -79,3 +80,4 @@ suites:
             - systemd.networkd
             - systemd.networkd.profiles
             - systemd.timesyncd
+            - systemd.units

--- a/systemd/networkd/profiles.sls
+++ b/systemd/networkd/profiles.sls
@@ -1,3 +1,6 @@
+include:
+  - systemd.reload
+
 {% for networkdprofile, profiles in salt['pillar.get']('systemd:networkd:profiles').items()  %}
   {% for profile, profileconfig in profiles.items() %}
 
@@ -11,8 +14,4 @@
       - cmd: reload_systemd_configuration
   {% endfor %}
 {% endfor %}
-
-reload_systemd_configuration:
-  cmd.wait:
-    - name: systemctl daemon-reload
 

--- a/systemd/reload.sls
+++ b/systemd/reload.sls
@@ -1,0 +1,4 @@
+reload_systemd_configuration:
+  cmd.wait:
+    - name: systemctl daemon-reload
+    - runas: root

--- a/systemd/units/init.sls
+++ b/systemd/units/init.sls
@@ -1,3 +1,6 @@
+include:
+  - systemd.reload
+
 {% import_yaml 'systemd/units/unittypes.yaml' as unittypes %}
 
 {% for unittype, units in pillar.get('systemd', {}).items()  %}
@@ -22,8 +25,4 @@ enable_{{ unit }}_{{ unittype }}:
     {% endfor %}
   {% endif %}
 {% endfor %}
-
-reload_systemd_configuration:
-  cmd.wait:
-    - name: systemctl daemon-reload
 

--- a/systemd/units/init.sls
+++ b/systemd/units/init.sls
@@ -1,5 +1,8 @@
-{% for unittype, units in pillar['systemd'].items()  %}
-{% for unit, unitconfig in units.items() %}
+{% import_yaml 'systemd/units/unittypes.yaml' as unittypes %}
+
+{% for unittype, units in pillar.get('systemd', {}).items()  %}
+  {% if unittype in unittypes.get('Valid') %}
+    {% for unit, unitconfig in units.items() %}
 
 /etc/systemd/system/{{ unit }}.{{ unittype }}:
   file.managed:
@@ -15,7 +18,9 @@ enable_{{ unit }}_{{ unittype }}:
     - name: systemctl enable {{ unit }}
     - watch:
       - cmd: reload_systemd_configuration
-{% endfor %}
+
+    {% endfor %}
+  {% endif %}
 {% endfor %}
 
 reload_systemd_configuration:

--- a/systemd/units/unittypes.yaml
+++ b/systemd/units/unittypes.yaml
@@ -1,0 +1,14 @@
+# Valid systemd unit types according to SYSTEMD.UNIT(5)
+
+Valid:
+  - service
+  - socket
+  - device
+  - mount
+  - automount
+  - swap
+  - target
+  - path
+  - timer
+  - slice
+  - scope


### PR DESCRIPTION
Hello,

At the moment, we loop over all _systemd_ pillar subkeys to find units to create, as we don't have e.g. a _systemd:units_ hierarchy with all the units behind it. Switching to the following model could help but would break existing setups:

```
systemd:
  units:
    service:
      syncthing-someuser:
        ...
    timer:
      timer-example:
        ...
```

In order to avoid a such regression, I added a list of supported unit types, so it's now possible to skip entries such as:

```
systemd:
  networkd:
    ...
  timesyncd:
    ...
```

Does it look ok or do we prefer to relocate units even if it breaks existing setups?

I also enabled systemd.units in Kitchen. Even if we don't have specific test items for now, it would have shown the issue described here.

The _reload_systemd_units_configuration_ renaming is done to avoid conflictings ids with _systemd.networkd_.

Best regards,