### PR TITLE
Make “files_switch” prefix a pillar prefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,15 @@ keys and different needs, I'm using TOFS.
 _Template Override and Files Switch_ (TOFS) pattern as described in the
 documentation file `TOFS_pattern.md`.
 
+We provide a little change to the original TOFS pattern, the
+`files_switch` macro consider the `prefix` as a pillar and not just
+the directory path to the `files/` directory. It then replace any
+colon `:` with slash `/` to form the directory prefix.
+
+So, to configure the `files_switch` value of `systemd.networkd` you
+must define the pillar `systemd:networkd:files_switch`. Another
+example is provided in `pillar.example` for `systemd.timesyncd`.
+
 .. note::
     See the full `Salt Formulas
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_ doc.

--- a/pillar.example
+++ b/pillar.example
@@ -50,3 +50,6 @@ systemd:
     lookup:
       timezone: 'UTC'
 
+    files_switch:
+      - id
+      - os_family

--- a/systemd/macros.jinja
+++ b/systemd/macros.jinja
@@ -8,7 +8,8 @@
     Files Switch (TOFS) pattern.
 
     Params:
-      * prefix: basename of the formula to be used as directory prefix
+      * prefix: pillar prefix to custom ':files_switch'. Colons ':'
+        are replaced by '/' to be used as directory prefix
       * files: ordered list of files to look for, with full path
       * default_files_switch: if there's no pillar 'prefix:files_switch'
         this is the ordered list of grains to use as selector switch of the
@@ -40,17 +41,18 @@
             - salt://xxx/files/default/etc/xxx/xxx.conf
             - salt://xxx/files/default/etc/xxx/xxx.conf.jinja
   #}
+  {%- set path_prefix = prefix|replace(':', '/') %}
   {%- set files_switch_list = salt['pillar.get'](prefix ~ ':files_switch',
                                            default_files_switch) %}
   {%- for grain in files_switch_list if grains.get(grain) is defined %}
     {%- for file in files %}
-    {%- set url = '- salt://' ~ prefix ~ '/files/' ~
+    {%- set url = '- salt://' ~ path_prefix ~ '/files/' ~
                   grains.get(grain) ~ file %}
 {{ url | indent(indent_width, true) }}
     {%- endfor %}
   {%- endfor %}
     {%- for file in files %}
-    {%- set url = '- salt://' ~ prefix ~ '/files/default' ~ file %}
+    {%- set url = '- salt://' ~ path_prefix ~ '/files/default' ~ file %}
 {{ url | indent(indent_width, true) }}
     {%- endfor %}
 {%- endmacro %}

--- a/systemd/networkd/init.sls
+++ b/systemd/networkd/init.sls
@@ -7,7 +7,7 @@ networkd:
     - user: root
     - group: root
     - template: jinja
-    - source: {{ files_switch('systemd/networkd', ['/network']) }}
+    - source: {{ files_switch('systemd:networkd', ['/network']) }}
     - clean: True
     - dir_mode: 755
     - file_mode: 644

--- a/systemd/resolved/init.sls
+++ b/systemd/resolved/init.sls
@@ -8,7 +8,7 @@ resolved:
     - group: root
     - mode: 644
     - template: jinja
-    - source: {{ files_switch('systemd/resolved', ['/resolved.conf']) }}
+    - source: {{ files_switch('systemd:resolved', ['/resolved.conf']) }}
     - listen_in:
       - service: resolved
   service.running:

--- a/systemd/timesyncd/init.sls
+++ b/systemd/timesyncd/init.sls
@@ -10,7 +10,7 @@ include:
 timesyncd:
   file.managed:
     - name: /etc/systemd/timesyncd.conf
-    - source: {{ files_switch('systemd/timesyncd', ['/timesyncd.conf']) }}
+    - source: {{ files_switch('systemd:timesyncd', ['/timesyncd.conf']) }}
   cmd.wait:
     - name: timedatectl set-ntp true
     - runas: root


### PR DESCRIPTION
Before we had to get a distinct pillar tree to configure
“files_switch”, for example “systemd/timesyncd:files_switch”.

This commit make it configurable with
“systemd:timesyncd:files_switch”.

* pillar.example: add default value of
  “systemd:timesyncd:files_switch”.

* systemd/macros.jinja: the “prefix” argument is now the pillar prefix
  to “files_switch”.
  Replace colon “:” in prefix with slash “/” to define the path prefix
  of file URLs.

* systemd/networkd/init.sls: switch files_switch prefix to
  “systemd:networkd”.

* systemd/resolved/init.sls: switch files_switch prefix to
  “systemd:resolved”.

* systemd/timesyncd/init.sls:  switch files_switch prefix to
  “systemd:timesyncd”.