### PR TITLE
fix(tofs): use literal pillar (config) paths instead of `tpldir`

### DIFF
--- a/systemd/networkd/init.sls
+++ b/systemd/networkd/init.sls
@@ -9,7 +9,7 @@ networkd:
     - template: jinja
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:networkd',
+                        'systemd:tofs:files:networkd',
                         ['network']
                     )
               ) }}

--- a/systemd/resolved/init.sls
+++ b/systemd/resolved/init.sls
@@ -10,7 +10,7 @@ resolved:
     - template: jinja
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:resolved',
+                        'systemd:tofs:files:resolved',
                         ['resolved.conf']
                     )
               ) }}

--- a/systemd/timesyncd/init.sls
+++ b/systemd/timesyncd/init.sls
@@ -13,7 +13,7 @@ timesyncd:
     - name: /etc/systemd/timesyncd.conf
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:timesyncd',
+                        'systemd:tofs:files:timesyncd',
                         ['timesyncd.conf']
                     )
               ) }}


### PR DESCRIPTION
* With nested `.sls` files, `tpldir` respectively resolves to:
  - `systemd/networkd`
  - `systemd/resolved`
  - `systemd/timesyncd`
* Without this fix, only the default value provided is ever used, respectively:
  - `['network']`
  - `['resolved.conf']`
  - `['timesyncd.conf']`

---

@aboe76 In my defense, I did [voice my concerns](https://freenode.logbot.info/saltstack-formulas/20190223#c2020898) about #17 being merged too quickly without full testing.  In any case, this isn't a substantial bug since all it prevents is the extra configurability which no-one is using right now.

I've gone for this simplest fix but I really am considering whether we should use [`topdir`](https://github.com/myii/template-formula/blob/52d03d895ac60cbcef64ca712881eee56d77c21a/template/map.jinja#L4-L10) in place of `tpldir` instead.  What's your take on that?