### PR TITLE
fix(kitchen+travis): update with recent `template-formula` findings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ env:
     - INSTANCE: fedora
     - INSTANCE: opensuse-42
 
-script: 
+script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source "https://rubygems.org"
 
-gem "test-kitchen"
-gem "kitchen-docker"
-gem "kitchen-salt"
-gem "kitchen-inspec"
-gem "net-ssh"
-gem "serverspec"
-gem "kitchen-verifier-serverspec"
+gem 'kitchen-docker', '>= 2.9'
+gem 'kitchen-salt', '>= 0.5.0'
+gem 'kitchen-inspec', '>= 1.1'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,8 +32,8 @@ platforms:
       run_command: /usr/lib/systemd/systemd
       pid_one_command: /usr/lib/systemd/systemd
   - name: debian-9
-    image: debian:9
     driver_config:
+      image: debian:9
       provision_command:
         - apt-get update && apt-get install -y udev locales
         - echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
@@ -43,7 +43,7 @@ platforms:
       pid_one_command: /lib/systemd/systemd
   - name: debian-8
     driver_config:
-      image: debian:jessie-backports
+      image: debian:8
       provision_command:
         - apt-get update && apt-get install -y udev locales
         - echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
@@ -91,7 +91,7 @@ provisioner:
   salt_copy_filter:
     - .kitchen
     - .git
-  pillars-from-files:
+  pillars_from_files:
     systemd.sls: pillar.example
   pillars:
     top.sls:


### PR DESCRIPTION
* https://github.com/saltstack-formulas/template-formula/pull/81
  - Update `Gemfile` inc. remove `serverspec` gems
* https://github.com/saltstack-formulas/template-formula/pull/74
  - Replace deprecated `pillars-from-files` with `pillars_from_files`
* https://github.com/saltstack-formulas/template-formula/pull/82
  - Use `debian:8` again since `python-systemd` now available
* Fix minor issues in config files