### PR TITLE
fix timesyncd cmd.wait

### DIFF
--- a/systemd/timesyncd/config.sls
+++ b/systemd/timesyncd/config.sls
@@ -43,11 +43,11 @@ timesyncd:
     {%- endif %}
     - listen_in:
       - service: timesyncd
+    - watch_in:
+      - cmd: timesyncd
   cmd.wait:
     - name: timedatectl set-ntp true
     - runas: root
-    - watch:
-      - file: timesyncd
   service.running:
     - name: systemd-timesyncd
     - enable: True


### PR DESCRIPTION
Needed to fix a small issue with cmd.wait, requisite reversed.