### PR TITLE
feature(tofs): lookup files directory in “tpldir” hierarchy

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -441,3 +441,75 @@ Resulting in:
            - salt://ntp/files/default/etc/ntp.conf.jinja
            - salt://ntp/files/default/etc/ntp.conf_alt.jinja
 
+Using sub-directories for ``components``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your formula is composed of several components, you may prefer to provides files under sub-directories, like in the `systemd-formula <https://github.com/saltstack-formulas/systemd-formula>`_.
+
+.. code-block::
+
+   /srv/saltstack/systemd-formula/
+     systemd/
+       init.sls
+       libtofs.jinja
+       map.jinja
+       networkd/
+         init.sls
+         files/
+           default/
+             network/
+               99-default.link
+       resolved/
+         init.sls
+         files/
+           default/
+             resolved.conf
+       timesyncd/
+         init.sls
+         files/
+           Arch/
+             resolved.conf
+           Debian/
+             resolved.conf
+           default/
+             resolved.conf
+           Ubuntu/
+             resolved.conf
+
+For example, the following ``formula.component.config`` SLS:
+
+.. code-block::
+
+   {%- from "formula/libtofs.jinja" import files_switch with context -%}
+
+   formula configuration file:
+     file.managed:
+       - name: /etc/formula.conf
+       - user: root
+       - group: root
+       - mode: 644
+       - template: jinja
+       - source: {{ files_switch(['formula.conf'],
+                                 lookup='formula'
+                    )
+                 }}
+
+will be rendered on a ``Debian`` named ``salt-formula.ci.local`` as:
+
+.. code-block::
+
+   formula configuration file:
+
+     file.managed:
+       - name: /etc/formula.conf
+       - user: root
+       - group: root
+       - mode: 644
+       - template: jinja
+       - source:
+         - salt://formula/component/files/salt-formula.ci.local/formula.conf
+         - salt://formula/component/files/Debian/formula.conf
+         - salt://formula/component/files/default/formula.conf
+         - salt://formula/files/salt-formula.ci.local/formula.conf
+         - salt://formula/files/Debian/formula.conf
+         - salt://formula/files/default/formula.conf

--- a/systemd/libtofs.jinja
+++ b/systemd/libtofs.jinja
@@ -67,8 +67,15 @@
   {%- set path_prefix_exts = [''] %}
   {%- if v1_path_prefix != '' %}
     {%- do path_prefix_exts.append(v1_path_prefix) %}
+  {%- elif tplroot != tpldir %}
+    {#- Walk directory tree to find {{ files_dir }} #}
+    {%- set subpath_parts = tpldir.lstrip(tplroot).lstrip('/').split('/') %}
+    {%- for path in subpath_parts %}
+      {%- set subpath = subpath_parts[0:loop.index] | join('/') %}
+      {%- do path_prefix_exts.append('/' ~ subpath) %}
+    {%- endfor %}
   {%- endif %}
-  {%- for path_prefix_ext in path_prefix_exts %}
+  {%- for path_prefix_ext in path_prefix_exts|reverse %}
     {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
     {#- For older TOFS implementation, use `files_switch` from the config #}
     {#- Use the default, new method otherwise #}

--- a/systemd/networkd/init.sls
+++ b/systemd/networkd/init.sls
@@ -14,8 +14,7 @@ networkd:
     - group: root
     - template: jinja
     - source: {{ files_switch(['network'],
-                              lookup='networkd',
-                              v1_path_prefix = '/networkd'
+                              lookup='networkd'
                  )
               }}
     - clean: True

--- a/systemd/resolved/config.sls
+++ b/systemd/resolved/config.sls
@@ -17,8 +17,7 @@ resolved:
     - mode: 644
     - template: jinja
     - source: {{ files_switch(['resolved.conf'],
-                              lookup='resolved',
-                              v1_path_prefix = '/resolved'
+                              lookup='resolved'
                               )
               }}
   {%- elif resolved.config_source == 'pillar' %}

--- a/systemd/timesyncd/config.sls
+++ b/systemd/timesyncd/config.sls
@@ -24,8 +24,7 @@ timesyncd:
     - mode: 644
     - template: jinja
     - source: {{ files_switch(['timesyncd.conf'],
-                              lookup='timesyncd',
-                              v1_path_prefix = '/timesyncd'
+                              lookup='timesyncd'
                               )
               }}
   {%- elif timesyncd.config_source == 'pillar' %}


### PR DESCRIPTION
Without user configuration, the “libtofs.jinja” lookup the “files”
directory under “tplroot” with is the base directory of the current
formula unless the “v1_path_prefix” is set.

Now, we lookup the directory in each sub-directory from the
sub-directory of the current SLS (“tpldir”) to the top level directory
of the formula (“tplroot”).

This permit to support natively the multi-components formula.