### PR TITLE
fix('networkd'): don't remove files when using profiles

### DIFF
--- a/systemd/networkd/init.sls
+++ b/systemd/networkd/init.sls
@@ -4,10 +4,11 @@
 {%- set networkd = systemd.get('networkd', {}) %}
 
 networkd:
-  {% if networkd.pkg %}
+  {%- if networkd.pkg %}
   pkg.installed:
     - name: {{ networkd.pkg }}
-  {% endif %}
+  {%- endif %}
+  {%- if networkd.profiles|length == 0 %}
   file.recurse:
     - name: {{ networkd.path }}
     - user: root
@@ -23,6 +24,7 @@ networkd:
     - include_empty: True
     - listen_in:
       - service: networkd
+  {%- endif %}
   service.running:
     - name: {{ networkd.service }} 
     - enable: True

--- a/systemd/networkd/profiles.sls
+++ b/systemd/networkd/profiles.sls
@@ -16,6 +16,11 @@ include:
   file.managed:
     - template: jinja
     - source: salt://systemd/networkd/templates/profile.jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - dir_mode: 755
     - context:
         config: {{ profileconfig|json }}
     - watch_in:

--- a/test/integration/default/controls/networkd_spec.rb
+++ b/test/integration/default/controls/networkd_spec.rb
@@ -9,10 +9,7 @@ control 'Systemd Networkd' do
   end
 
   describe file('/etc/systemd/network/99-default.link') do
-    its('type') { should eq :file }
-    its('mode') { should cmp '0644' }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
+    it { should_not exist }
   end
 
   describe file('/etc/systemd/network/eth0.network') do


### PR DESCRIPTION
while using networkd:profiles running networkd.init would remove the files.
not anymore testing if pillar profiles is filled skip file recurse.