### PR TITLE
fix(path): specify unit type when enabling systemd unit

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -34,13 +34,22 @@ systemd:
       Unit:
         Description: Syncthing P2P sync service for someuser
         After: network.target
-  
+
       Service:
         ExecStart: /usr/bin/syncthing
         User: someuser
         Group: someuser
         Environment: STNORESTART=yes HOME=/home/someuser
-  
+
+      Install:
+        WantedBy: multi-user.target
+
+  path:
+    triger-service-on-changes:
+      Path:
+        PathModified: /path/to/watch
+        Unit: oneshot_service_to_trigger.service
+
       Install:
         WantedBy: multi-user.target
 
@@ -81,7 +90,7 @@ systemd:
           - Network:
             - DHCP: "yes"
 
-      ## br0.netdev      
+      ## br0.netdev
       netdev:
         br0:
           - NetDev:
@@ -92,7 +101,7 @@ systemd:
             - MaxAgeSec: 0
             - ForwardDelaySec: 0
             - STP: 'no'
-      
+
       ## 10-dmz.link
       link:
         10-dmz:

--- a/systemd/units/init.sls
+++ b/systemd/units/init.sls
@@ -18,7 +18,7 @@ include:
 
 enable_{{ unit }}_{{ unittype }}:
   cmd.wait:
-    - name: systemctl enable {{ unit }}
+    - name: systemctl enable {{ unit }}.{{ unittype }}
     - watch:
       - cmd: reload_systemd_configuration
 


### PR DESCRIPTION
By default service units are assumed, however there are cases where you want to
enable path units, etc. This will enable a unit using {{ unit }}.{{unittype }}.

 Fixes #41