### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -44,16 +44,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -20,13 +20,13 @@ systemd:
     # dirs:
     #   files: files_alt
     #   default: default_alt
-    # source_files:
-    #   networkd:
-    #     - 'network'
-    #   resolved:
-    #     - 'resolved.conf'
-    #   timesyncd:
-    #     - 'timesyncd.conf'
+    source_files:
+      networkd:
+        - 'alt_network'
+      resolved:
+        - 'alt_resolved.conf'
+      timesyncd:
+        - 'alt_timesyncd.conf'
 
   ## units
   service:
@@ -82,37 +82,37 @@ systemd:
   ## networkd
   networkd:
     profiles:
-      ## eth0.network
       network:
+        # eth0.network
         eth0:
           - Match:
-            - Name: eth0
+              - Name: eth0
           - Network:
-            - DHCP: "yes"
+              - DHCP: "yes"
 
-      ## br0.netdev
       netdev:
+        # br0.netdev
         br0:
           - NetDev:
-            - Name: br0
-            - Kind: bridge
+              - Name: br0
+              - Kind: bridge
           - Bridge:
-            - HelloTimeSec: 0
-            - MaxAgeSec: 0
-            - ForwardDelaySec: 0
-            - STP: 'no'
+              - HelloTimeSec: 0
+              - MaxAgeSec: 0
+              - ForwardDelaySec: 0
+              - STP: 'no'
 
-      ## 10-dmz.link
       link:
+        # 10-dmz.link
         10-dmz:
           - Match:
-            - MACAddress: '00:a0:de:63:7a:e6'
+              - MACAddress: '00:a0:de:63:7a:e6'
           - Link:
-            - Name: dmz0
+              - Name: dmz0
 
-      # 10-internet.link
+        # 10-internet.link
         10-internet:
           - Match:
-            - Path: 'pci-0000:00:1a.0-*'
+              - Path: 'pci-0000:00:1a.0-*'
           - Link:
-            - Name: internet0
+              - Name: internet0

--- a/systemd/defaults.yaml
+++ b/systemd/defaults.yaml
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
+---
 systemd:
   pkg: systemd
   pkgs_libs: []
@@ -21,7 +22,7 @@ systemd:
     pkg: {}
     path: /etc/systemd/network
     service: systemd-networkd
-    wait_online: True
+    wait_online: true
 
   resolved:
     config_source: file
@@ -39,5 +40,3 @@ systemd:
       Cache: 'yes'
       DNSStubListener: 'yes'
       ReadEtcHosts: 'yes'
-
-

--- a/systemd/osfamilymap.yaml
+++ b/systemd/osfamilymap.yaml
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                                                             
+# -*- coding: utf-8 -*-
 # vim: ft=yaml
 #
 # Setup variables using grains['os_family'] based logic.
@@ -18,9 +18,9 @@ Debian:
     resolv_target: /run/systemd/resolve/resolv.conf
 
 RedHat:
-  pkgs_libs: 
+  pkgs_libs:
     - systemd-libs
-  pkgs_extra: 
+  pkgs_extra:
     - systemd-python
   resolved:
     pkg: systemd-resolved
@@ -44,5 +44,3 @@ Suse:
     - util-linux-systemd
   resolved:
     pkg: nss-resolve
-
-

--- a/systemd/units/unittypes.yaml
+++ b/systemd/units/unittypes.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # Valid systemd unit types according to SYSTEMD.UNIT(5)
 
 Valid:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: systemd formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
systemd-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./systemd/defaults.yaml
  3:1       warning  missing document start "---"  (document-start)
  24:18     warning  truthy value should be one of [false, true]  (truthy)
  43:1      error    too many blank lines (2 > 0)  (empty-lines)

./systemd/osfamilymap.yaml
  1:89      error    line too long (116 > 88 characters)  (line-length)
  1:24      error    trailing spaces  (trailing-spaces)
  21:13     error    trailing spaces  (trailing-spaces)
  23:14     error    trailing spaces  (trailing-spaces)
  48:1      error    too many blank lines (2 > 0)  (empty-lines)

./systemd/units/unittypes.yaml
  3:1       warning  missing document start "---"  (document-start)

pillar.example
  18:5      warning  comment not indented like content  (comments-indentation)
  89:13     error    wrong indentation: expected 14 but found 12  (indentation)
  91:13     error    wrong indentation: expected 14 but found 12  (indentation)
  97:13     error    wrong indentation: expected 14 but found 12  (indentation)
  100:13    error    wrong indentation: expected 14 but found 12  (indentation)
  109:13    error    wrong indentation: expected 14 but found 12  (indentation)
  111:13    error    wrong indentation: expected 14 but found 12  (indentation)
  113:7     warning  comment not indented like content  (comments-indentation)
  116:13    error    wrong indentation: expected 14 but found 12  (indentation)
  118:13    error    wrong indentation: expected 14 but found 12  (indentation)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.