### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -493,7 +493,8 @@ For example, the following ``formula.component.config`` SLS:
        - mode: 644
        - template: jinja
        - source: {{ files_switch(['formula.conf'],
-                                 lookup='formula'
+                                 lookup='formula',
+                                 use_subpath=True
                     )
                  }}
 

--- a/systemd/libtofs.jinja
+++ b/systemd/libtofs.jinja
@@ -2,7 +2,7 @@
                        lookup=None,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6,
-                       v1_path_prefix='') %}
+                       use_subpath=False) %}
   {#-
     Returns a valid value for the "source" parameter of a "file.managed"
     state function. This makes easier the usage of the Template Override and
@@ -17,8 +17,8 @@
         use as selector switch of the directories under
         "<path_prefix>/files"
       * indent_witdh: indentation of the result value to conform to YAML
-      * v1_path_prefix: (deprecated) only used for injecting a path prefix into
-        the source, to support older TOFS configs
+      * use_subpath: defaults to `False` but if set, lookup the source file
+        recursively from the current state directory up to `tplroot`
 
     Example (based on a `tplroot` of `xxx`):
 
@@ -64,9 +64,7 @@
   {%- set src_files = src_files + source_files %}
   {#- Only add to [''] when supporting older TOFS implementations #}
   {%- set path_prefix_exts = [''] %}
-  {%- if v1_path_prefix != '' %}
-    {%- do path_prefix_exts.append(v1_path_prefix) %}
-  {%- elif tplroot != tpldir %}
+  {%- if use_subpath and tplroot != tpldir %}
     {#- Walk directory tree to find {{ files_dir }} #}
     {%- set subpath_parts = tpldir.lstrip(tplroot).lstrip('/').split('/') %}
     {%- for path in subpath_parts %}

--- a/systemd/networkd/init.sls
+++ b/systemd/networkd/init.sls
@@ -15,7 +15,8 @@ networkd:
     - group: root
     - template: jinja
     - source: {{ files_switch(['network'],
-                              lookup='networkd'
+                              lookup='networkd',
+                              use_subpath=True
                  )
               }}
     - clean: True

--- a/systemd/resolved/config.sls
+++ b/systemd/resolved/config.sls
@@ -17,7 +17,8 @@ resolved:
     - mode: 644
     - template: jinja
     - source: {{ files_switch(['resolved.conf'],
-                              lookup='resolved'
+                              lookup='resolved',
+                              use_subpath=True
                               )
               }}
   {%- elif resolved.config_source == 'pillar' %}

--- a/systemd/timesyncd/config.sls
+++ b/systemd/timesyncd/config.sls
@@ -24,7 +24,8 @@ timesyncd:
     - mode: 644
     - template: jinja
     - source: {{ files_switch(['timesyncd.conf'],
-                              lookup='timesyncd'
+                              lookup='timesyncd',
+                              use_subpath=True
                               )
               }}
   {%- elif timesyncd.config_source == 'pillar' %}


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.6.0)
* Add `use_subpath=True` to each `files_switch` call