### PR TITLE
networkd reload

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -121,12 +121,17 @@ systemd:
 
   ## networkd
   networkd:
+    fileattr:
+      br0.network:
+        user: systemd-network
+        group: systemd-network
+        mode: "0600"
     profiles:
       network:
-        # eth0.network
-        eth0:
+        # br0.network
+        br0:
           - Match:
-              - Name: eth0
+              - Name: br0
           - Network:
               - DHCP: "yes"
 

--- a/systemd/defaults.yaml
+++ b/systemd/defaults.yaml
@@ -19,6 +19,8 @@ systemd:
       PollIntervalMaxSec: 2048
 
   networkd:
+    # networkctl reload is available since systemd 244
+    networkctl_reload: false
     pkg: {}
     path: /etc/systemd/network
     service: systemd-networkd

--- a/systemd/defaults.yaml
+++ b/systemd/defaults.yaml
@@ -22,6 +22,7 @@ systemd:
     # networkctl reload is available since systemd 244
     networkctl_reload: false
     pkg: {}
+    fileattr: {}
     path: /etc/systemd/network
     service: systemd-networkd
     wait_online: true

--- a/systemd/networkd/profiles.sls
+++ b/systemd/networkd/profiles.sls
@@ -5,8 +5,10 @@
 {%- set networkd = systemd.get('networkd', {}) %}
 {%- set profiles = networkd.get('profiles', {}) %}
 
+{%- if networkd.networkctl_reload %}
 include:
-  - systemd.reload
+  - systemd.networkd.reload
+{%- endif %}
 
 {% if profiles is mapping %}
 {% for networkdprofile, types in profiles.items()  %}
@@ -23,8 +25,10 @@ include:
     - dir_mode: 755
     - context:
         config: {{ profileconfig|json }}
+{%- if networkd.networkctl_reload %}
     - watch_in:
-      - cmd: reload_systemd_configuration
-  {% endfor %}
-{% endfor %}
-{% endif %}
+      - cmd: systemd-networkd-reload-cmd-wait
+{%- endif %}
+  {%- endfor %}
+{%- endfor %}
+{%- endif %}

--- a/systemd/networkd/profiles.sls
+++ b/systemd/networkd/profiles.sls
@@ -10,21 +10,33 @@ include:
   - systemd.networkd.reload
 {%- endif %}
 
-{% if profiles is mapping %}
-{% for networkdprofile, types in profiles.items()  %}
-  {% for profile, profileconfig in types.items() %}
+{%- if profiles is mapping %}
 
-/etc/systemd/network/{{ profile }}.{{ networkdprofile }}:
+/etc/systemd/network:
+  file.directory:
+    - user: root
+    - group: root
+    - makedirs: true
+    - dir_mode: 755
+
+{%- for networkdprofile, types in profiles.items()  %}
+  {%- for profile, profileconfig in types.items() %}
+  {%- set filename = profile ~ "." ~ networkdprofile %}
+  {%- set user = networkd.fileattr.get(filename, {}).user | default("root") %}
+  {%- set group = networkd.fileattr.get(filename, {}).group | default("root") %}
+  {%- set mode = networkd.fileattr.get(filename, {}).mode | default("0644") %}
+
+/etc/systemd/network/{{ filename }}:
   file.managed:
     - template: jinja
     - source: salt://systemd/networkd/templates/profile.jinja
-    - user: root
-    - group: root
-    - mode: '0644'
-    - makedirs: true
-    - dir_mode: 755
+    - user: {{ user }}
+    - group: {{ group }}
+    - mode: {{ mode }}
     - context:
         config: {{ profileconfig|json }}
+    - require:
+      - file: /etc/systemd/network
 {%- if networkd.networkctl_reload %}
     - watch_in:
       - cmd: systemd-networkd-reload-cmd-wait

--- a/systemd/networkd/reload.sls
+++ b/systemd/networkd/reload.sls
@@ -1,0 +1,9 @@
+include:
+  - systemd.networkd
+
+systemd-networkd-reload-cmd-wait:
+  cmd.wait:
+    - name: networkctl reload
+    - runas: root
+    - require:
+      - service: networkd

--- a/systemd/networkd/templates/profile.jinja
+++ b/systemd/networkd/templates/profile.jinja
@@ -16,7 +16,7 @@
                 {%- endfor -%}
             {%- endif -%}
         {%- endfor %}
-    {% endfor %}
+    {%- endfor %}
 {%- endmacro -%}
 
 # This file is managed by Salt via {{ source }}

--- a/systemd/osmap.yaml
+++ b/systemd/osmap.yaml
@@ -14,6 +14,7 @@ Fedora:
   pkgs_extra:
     - python3-systemd
   networkd:
+    networkctl_reload: true
     pkg: {}
   resolved:
     pkg: {}

--- a/test/integration/default/controls/networkd_spec.rb
+++ b/test/integration/default/controls/networkd_spec.rb
@@ -14,11 +14,11 @@ control 'Systemd Networkd' do
     it { should_not exist }
   end
 
-  describe file('/etc/systemd/network/eth0.network') do
+  describe file('/etc/systemd/network/br0.network') do
     its('type') { should eq :file }
-    its('mode') { should cmp '0644' }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
+    its('mode') { should cmp '0600' }
+    its('owner') { should eq 'systemd-network' }
+    its('group') { should eq 'systemd-network' }
   end
 
   describe file('/etc/systemd/network/br0.netdev') do


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->
none


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

* Allow to configure user/group/mode of networkd configuration files to
  set e.g. systemd-networkd or a specific mode for sensitive
  configuration.
* Use `networkctl reload` to reload the network configuration.
* networkd/template: remove empty lines with spaces

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

TODO:
- [x] use `networkctl reload` only when available
- [x] update tests that connectivity is not lost
- [x] handle cases when ~systemd-network is not available as user/group~ /etc/systemd/network folder is not available